### PR TITLE
Adding sympy to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pandas
   - scipy
   - networkx
+  - sympy
   - pip
   - pip:
     - thinkbayes2


### PR DESCRIPTION
My version of anaconda/jupyter did not have sympy installed, so the following commands:
`from sympy import symbols`
`p = symbols('p')`
fail in monty.ipynb.